### PR TITLE
segregate payment context and strategy

### DIFF
--- a/15_strategy/strategy.go
+++ b/15_strategy/strategy.go
@@ -2,23 +2,29 @@ package strategy
 
 import "fmt"
 
+type Payment struct {
+	context  *PaymentContext
+	strategy PaymentStrategy
+}
+
 type PaymentContext struct {
 	Name, CardID string
 	Money        int
-	payment      PaymentStrategy
 }
 
-func NewPaymentContext(name, cardid string, money int, payment PaymentStrategy) *PaymentContext {
-	return &PaymentContext{
-		Name:    name,
-		CardID:  cardid,
-		Money:   money,
-		payment: payment,
+func NewPayment(name, cardid string, money int, strategy PaymentStrategy) *Payment {
+	return &Payment{
+		context: &PaymentContext{
+			Name:   name,
+			CardID: cardid,
+			Money:  money,
+		},
+		strategy: strategy,
 	}
 }
 
-func (p *PaymentContext) Pay() {
-	p.payment.Pay(p)
+func (p *Payment) Pay() {
+	p.strategy.Pay(p.context)
 }
 
 type PaymentStrategy interface {

--- a/15_strategy/strategy_test.go
+++ b/15_strategy/strategy_test.go
@@ -1,15 +1,15 @@
 package strategy
 
 func ExamplePayByCash() {
-	ctx := NewPaymentContext("Ada", "", 123, &Cash{})
-	ctx.Pay()
+	payment := NewPayment("Ada", "", 123, &Cash{})
+	payment.Pay()
 	// Output:
 	// Pay $123 to Ada by cash
 }
 
 func ExamplePayByBank() {
-	ctx := NewPaymentContext("Bob", "0002", 888, &Bank{})
-	ctx.Pay()
+	payment := NewPayment("Bob", "0002", 888, &Bank{})
+	payment.Pay()
 	// Output:
 	// Pay $888 to Bob by bank account 0002
 }


### PR DESCRIPTION
previous PaymentContext includes PaymentStrategy, it could lead to
undesired recursive calls in interface PaymentStrategy.Pay(*PaymentContext)